### PR TITLE
Добавление поддержки "регионов" в google

### DIFF
--- a/lib/seotracker.rb
+++ b/lib/seotracker.rb
@@ -25,7 +25,7 @@ class Seotracker
   # получаем массив ссылок от парсера
   # увеличиваем счетчик позиций, пока не найдем нужную ссылку
   # 4 ссылки храним в массиве "последних", чтобы не считать случайно выдранные парсером повторения
-  def get_position(site, word, region = Seotracker::Yandex::MOSCOW, pages = 200)
+  def get_position(site, word, region = nil, pages = 200)
     pos, found, start, hrefs = 0, false, 0, []
     while (start < pages) && !found
       links = parse(word, start, region)

--- a/lib/seotracker/google.rb
+++ b/lib/seotracker/google.rb
@@ -1,10 +1,13 @@
 class Seotracker::Google < Seotracker
-  SEARCH_URL = "http://www.google.ru/search?ix=seb&sourceid=chrome&ie=UTF-8"
-
   protected
 
+  def search_url(region = nil)
+    region = 'www.google.ru' if region.nil?
+    "http://#{region}/search?ix=seb&sourceid=chrome&ie=UTF-8"
+  end
+
   def parse(word, start = 0, region = nil)
-    page = @agent.get(SEARCH_URL, q: word, start: start)
+    page = @agent.get(search_url(region), q: word, start: start)
     page.root.xpath('/html/body/div[5]/div/div/div[4]/div[2]/div[2]/div/div[2]/div/ol/li/div/h3/a')
   end
 end

--- a/lib/seotracker/yandex.rb
+++ b/lib/seotracker/yandex.rb
@@ -23,6 +23,8 @@ class Seotracker::Yandex < Seotracker
 
   # начинаем парсить с первой страницы, регион по умолчанию - Москва
   def parse(word, start = 0, region = nil)
+    region = MOSCOW if region.nil?
+
     start /= 10
     @cookie || get_cookie
     url = SEARCH_URL + "text=#{word}&p=#{start}&lr=#{region}"

--- a/spec/lib/seotracker_spec.rb
+++ b/spec/lib/seotracker_spec.rb
@@ -51,7 +51,7 @@ describe Seotracker do
 
       # мокаем все неважное
       mock = common_mocker
-      mock.expect(:get, mock, [Seotracker::Google::SEARCH_URL, {q: @word, start: 0}])
+      mock.expect(:get, mock, [Seotracker::Google.new.send(:search_url), {q: @word, start: 0}])
       mock.expect(:xpath, [mock], %w\/html/body/div[5]/div/div/div[4]/div[2]/div[2]/div/div[2]/div/ol/li/div/h3/a\)
 
       @object.instance_variable_set(:@agent, mock)


### PR DESCRIPTION
Аналогом яндексовых "регионов" в гугле является домен, на который происходит запрос. Соответственно, добавил код для изменения домена, через который происходит запрос.

Пример:

seot = Seotracker::Google.new
seot.get_position('dt.ua', 'dt') # умолчание - российский гугл
 => 27 
seot.get_position('dt.ua', 'dt', 'google.com.ua') # поиск украинским гуглом
 => 1 
